### PR TITLE
:sparkles: Added new user time measurement features

### DIFF
--- a/app/src/main/java/de/tuchemnitz/armadillogin/ui/login/LoginKeyFragment.kt
+++ b/app/src/main/java/de/tuchemnitz/armadillogin/ui/login/LoginKeyFragment.kt
@@ -64,6 +64,9 @@ class LoginKeyFragment : Fragment() {
 
     // sendLoginRequest and onActivityResult are used as shown in https://github.com/googlecodelabs/fido2-codelab
     fun sendLoginRequest() {
+        if (studyUserViewModel.userLoginStartTime == null) {
+            studyUserViewModel.userLoginStartTime = System.nanoTime()
+        }
         userViewModel.signInRequest().observeOnce(this) { pendingIntent ->
             startIntentSenderForResult(
                 pendingIntent.getIntentSender(),
@@ -108,7 +111,9 @@ class LoginKeyFragment : Fragment() {
                         // observe whether signInResponse already completed and suceeded and if so, go to next fragment
                         userViewModel.signInReady.observe(viewLifecycleOwner) { signInReady ->
                             if (signInReady) {
-                                studyUserViewModel.userFinishedTime = System.nanoTime()
+                                if(studyUserViewModel.userFinishedTime == null) {
+                                    studyUserViewModel.userFinishedTime = System.nanoTime()
+                                }
                                 studyUserViewModel.calculateUserTime()
                                 findNavController().navigate(R.id.action_navigation_login_key_to_navigation_user_overview)
                                 userViewModel.setSignInKey()

--- a/app/src/main/java/de/tuchemnitz/armadillogin/ui/register/RegisterFinishedFragment.kt
+++ b/app/src/main/java/de/tuchemnitz/armadillogin/ui/register/RegisterFinishedFragment.kt
@@ -11,6 +11,7 @@ import de.tuchemnitz.armadillogin.R
 import de.tuchemnitz.armadillogin.databinding.FragmentRegisterFinishedBinding
 import de.tuchemnitz.armadillogin.model.ArmadilloViewModel
 import de.tuchemnitz.armadillogin.model.FragmentStatus
+import de.tuchemnitz.armadillogin.model.StudyUserDataViewModel
 import de.tuchemnitz.armadillogin.model.UserDataViewModel
 
 /**
@@ -22,6 +23,7 @@ class RegisterFinishedFragment : Fragment() {
     private var binding: FragmentRegisterFinishedBinding? = null
     private val userViewModel: UserDataViewModel by activityViewModels()
     private val sharedViewModel: ArmadilloViewModel by activityViewModels()
+    private val studyUserDataViewModel: StudyUserDataViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/de/tuchemnitz/armadillogin/ui/register/RegisterKeyFragment.kt
+++ b/app/src/main/java/de/tuchemnitz/armadillogin/ui/register/RegisterKeyFragment.kt
@@ -17,6 +17,7 @@ import de.tuchemnitz.armadillogin.R
 import de.tuchemnitz.armadillogin.databinding.FragmentRegisterKeyBinding
 import de.tuchemnitz.armadillogin.model.ArmadilloViewModel
 import de.tuchemnitz.armadillogin.model.FragmentStatus
+import de.tuchemnitz.armadillogin.model.StudyUserDataViewModel
 import de.tuchemnitz.armadillogin.model.UserDataViewModel
 import de.tuchemnitz.armadillogin.ui.observeOnce
 
@@ -35,6 +36,7 @@ class RegisterKeyFragment : Fragment() {
     private var binding: FragmentRegisterKeyBinding? = null
     private val sharedViewModel: ArmadilloViewModel by activityViewModels()
     private val userViewModel: UserDataViewModel by activityViewModels()
+    private val studyUserDataViewModel: StudyUserDataViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -62,6 +64,9 @@ class RegisterKeyFragment : Fragment() {
 
     // sendRegisterRequest and onActivityResult are used as shown in https://github.com/googlecodelabs/fido2-codelab
     fun sendRegisterRequest() {
+        if (studyUserDataViewModel.userRegisterStartTime == null) {
+            studyUserDataViewModel.userRegisterStartTime = System.nanoTime()
+        }
         userViewModel.registerRequest().observeOnce(requireActivity()) { pendingIntent ->
             startIntentSenderForResult(
                 pendingIntent.getIntentSender(),
@@ -99,9 +104,12 @@ class RegisterKeyFragment : Fragment() {
                 data != null -> {
                     userViewModel.registerResponse(data)
 
-                    // inserted by winkloid - navigate to RegisterFinishedFragment after data transmission
+                    // inserted by winkloid - navigate to RegisterFinishedFragment after data transmission and store register finished time
                     userViewModel.registeringKey.observe(viewLifecycleOwner) { registeringKey ->
                         if (!registeringKey) {
+                            if (studyUserDataViewModel.userRegisterFinishedTime == null) {
+                                studyUserDataViewModel.userRegisterFinishedTime = System.nanoTime()
+                            }
                             findNavController().navigate(R.id.action_navigation_register_key_to_navigation_register_finished)
                         }
                     }

--- a/app/src/main/java/de/tuchemnitz/armadillogin/ui/welcome/UserDataFragment.kt
+++ b/app/src/main/java/de/tuchemnitz/armadillogin/ui/welcome/UserDataFragment.kt
@@ -54,7 +54,9 @@ class UserDataFragment : Fragment() {
     fun goToNextView() {
         val valuesCorrect = checkValues()
         if (valuesCorrect) {
-            studyUserViewModel.userStartTime = System.nanoTime()
+            if(studyUserViewModel.userStartTime == null) {
+                studyUserViewModel.userStartTime = System.nanoTime()
+            }
             findNavController().navigate(R.id.action_navigation_user_data_to_navigation_register_login)
         }
     }


### PR DESCRIPTION
- Register Intent time and login intent time can be measured and stored separately now.
- All time values are secured now: If the time has already been recorded, it can't be recorded again.
- This solves issue #30 